### PR TITLE
Increased the width of ExceptionParams.timestamp

### DIFF
--- a/src/domain/runtime/event/mod.rs
+++ b/src/domain/runtime/event/mod.rs
@@ -19,7 +19,7 @@ pub enum Event {
 #[non_exhaustive]
 #[serde(rename_all = "camelCase")]
 pub struct ExceptionParams {
-    pub timestamp: i32,
+    pub timestamp: i64,
     pub exception_details: ExceptionDetails,
 }
 


### PR DESCRIPTION
Should fix cloudflare/wrangler#1835 (an overflow seems to be preventing parsing of the runtime message in [socket.rs](https://github.com/cloudflare/wrangler/blob/master/src/commands/dev/socket.rs#L105)).